### PR TITLE
Fix runtime frame streaming edge cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,4 @@ cd avatar-slides
 git add .
 git commit -m "initial MVP"
 git push
+```

--- a/app/musetalk_runner.py
+++ b/app/musetalk_runner.py
@@ -22,10 +22,15 @@ class MuseTalkStreamer:
 
     async def _read_frames(self):
         while True:
-            hdr = await self.proc.stdout.readexactly(4)
-            length = int.from_bytes(hdr, "big")
-            jpg = await self.proc.stdout.readexactly(length)
-            self.queue.put_nowait(base64.b64encode(jpg).decode())
+            try:
+                hdr = await self.proc.stdout.readexactly(4)
+                length = int.from_bytes(hdr, "big")
+                jpg = await self.proc.stdout.readexactly(length)
+                self.queue.put_nowait(base64.b64encode(jpg).decode())
+            except asyncio.IncompleteReadError:
+                break
+            except Exception:
+                break
 
     async def next_frame(self):
         return await asyncio.wait_for(self.queue.get(), timeout=0.1)


### PR DESCRIPTION
## Summary
- properly terminate README example code block
- handle incomplete reads in MuseTalkStreamer

## Testing
- `python3 -m py_compile app/main.py app/musetalk_runner.py`

------
https://chatgpt.com/codex/tasks/task_e_6885cfab57d483318234efbc428a8b89