### PR TITLE
Add slides playback alongside avatar

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -49,7 +49,8 @@ async def upload(video: UploadFile, audio: UploadFile, timestamps: UploadFile, f
 
     return {
         "id": uid,
-        "output_video": f"{uid}.mp4"
+        "output_video": f"{uid}.mp4",
+        "slides_video": f"{uid}_video.mp4"
     }
 
 @app.websocket("/ws/avatar/{uid}")

--- a/app/musetalk_runner.py
+++ b/app/musetalk_runner.py
@@ -11,13 +11,16 @@ class MuseTalkStreamer:
         self.proc = None
 
     async def start(self):
+        # Use the musetalk package as a module so imports work
         cmd = [
-            "python3", "musetalk/scripts/realtime_inference.py",
+            "python3", "-m", "musetalk.scripts.realtime_inference",
             "--inference_config", "musetalk/configs/inference/realtime.yaml",
             "--audio_clips", self.audio,
             "--avatar_id", "0"
         ]
-        self.proc = await asyncio.create_subprocess_exec(*cmd, stdout=subprocess.PIPE)
+        self.proc = await asyncio.create_subprocess_exec(
+            *cmd, stdout=subprocess.PIPE
+        )
         asyncio.create_task(self._read_frames())
 
     async def _read_frames(self):
@@ -40,8 +43,9 @@ class MuseTalkStreamer:
             self.proc.kill()
 
 def run_musetalk(audio_path, face_img, output_path):
+    # Run inference module via -m so that musetalk package is on PYTHONPATH
     cmd = [
-        "python3", "musetalk/scripts/inference.py",
+        "python3", "-m", "musetalk.scripts.inference",
         "--pose_style", "0",
         "--audio_path", audio_path,
         "--output_path", output_path,

--- a/static/index.html
+++ b/static/index.html
@@ -18,12 +18,12 @@
       display: flex;
       flex: 1;
     }
-    #videoBox {
-      flex: 3;
+    #slidesBox, #avatarBox {
+      flex: 1;
       position: relative;
       background: black;
     }
-    #outputVideo {
+    #slidesVideo, #outputVideo {
       width: 100%;
       height: 100%;
     }
@@ -64,9 +64,12 @@
 <body>
   <div id="root">
     <div id="playerRow">
-      <div id="videoBox">
-        <video id="outputVideo" controls></video>
+      <div id="slidesBox">
+        <video id="slidesVideo" muted controls></video>
         <div id="slideInfo">Slide 0</div>
+      </div>
+      <div id="avatarBox">
+        <video id="outputVideo" controls></video>
       </div>
       <div id="controls">
         <label>Slides video:


### PR DESCRIPTION
## Summary
- return slides video path from backend
- show slides next to avatar on frontend
- synchronize slides video with avatar playback
- run MuseTalk scripts from repository root so imports resolve

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6885d17d82608331be3a99fd4121f215