### PR TITLE
Add playback controls for slides and avatar

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -59,6 +59,11 @@
       font-weight: 600;
       cursor: pointer;
     }
+    #playbackControls {
+      display: flex;
+      gap: 8px;
+      margin-top: 8px;
+    }
   </style>
 </head>
 <body>
@@ -87,6 +92,11 @@
         </label>
         <button id="uploadBtn">Upload & Generate Avatar</button>
         <button id="streamBtn">Start Real-Time</button>
+        <div id="playbackControls">
+          <button id="backBtn">&#9664;&#9664; 5s</button>
+          <button id="playPauseBtn">Play</button>
+          <button id="forwardBtn">5s &#9654;&#9654;</button>
+        </div>
       </div>
     </div>
   </div>

--- a/static/main.js
+++ b/static/main.js
@@ -2,9 +2,33 @@ const outputVideo = document.getElementById('outputVideo');
 const slidesVideo = document.getElementById('slidesVideo');
 const slideInfo = document.getElementById('slideInfo');
 const avatarFrame = document.getElementById('avatarFrame');
+const playPauseBtn = document.getElementById('playPauseBtn');
+const backBtn = document.getElementById('backBtn');
+const forwardBtn = document.getElementById('forwardBtn');
 
 let timestamps = [];
 let currentId = null;
+
+playPauseBtn.onclick = () => {
+  if (outputVideo.paused) {
+    outputVideo.play();
+  } else {
+    outputVideo.pause();
+  }
+};
+
+backBtn.onclick = () => {
+  const newTime = Math.max(0, outputVideo.currentTime - 5);
+  outputVideo.currentTime = newTime;
+  slidesVideo.currentTime = newTime;
+};
+
+forwardBtn.onclick = () => {
+  const dur = isNaN(outputVideo.duration) ? Infinity : outputVideo.duration;
+  const newTime = Math.min(dur, outputVideo.currentTime + 5);
+  outputVideo.currentTime = newTime;
+  slidesVideo.currentTime = newTime;
+};
 
 document.getElementById('uploadBtn').onclick = async () => {
   const videoFile = document.getElementById('videoFile').files[0];
@@ -57,10 +81,12 @@ document.getElementById('uploadBtn').onclick = async () => {
 outputVideo.onplay = () => {
   slidesVideo.currentTime = outputVideo.currentTime;
   slidesVideo.play();
+  playPauseBtn.textContent = 'Pause';
 };
 
 outputVideo.onpause = () => {
   slidesVideo.pause();
+  playPauseBtn.textContent = 'Play';
 };
 
 outputVideo.ontimeupdate = () => {


### PR DESCRIPTION
## Summary
- add new Play/Pause, Back and Forward buttons
- sync new controls with avatar and slides playback

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `node --check static/main.js`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688920f49a808331903798fad8d3a084