### PR TITLE
Use single avatar video for chat responses

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -23,7 +23,7 @@
       position: relative;
       background: black;
     }
-    #slidesVideo, #outputVideo {
+    #slidesVideo, #outputVideo, #chatVideo {
       width: 100%;
       height: 100%;
     }
@@ -76,6 +76,7 @@
       <div id="avatarBox">
         <img id="avatarFrame" style="width:100%;height:100%;object-fit:contain"/>
         <video id="outputVideo" style="display:none" controls></video>
+        <video id="chatVideo" style="display:none" controls></video>
       </div>
       <div id="controls">
         <label>Slides video:
@@ -100,7 +101,6 @@
         <textarea id="chatInput" rows="3" placeholder="Ask a question..."></textarea>
         <button id="chatBtn">Ask GPT</button>
         <div id="chatAnswer"></div>
-        <video id="chatVideo" style="display:none" controls></video>
       </div>
     </div>
   </div>

--- a/static/main.js
+++ b/static/main.js
@@ -156,15 +156,18 @@ chatBtn.onclick = async () => {
     const data = await res.json();
     if (!res.ok) throw new Error(data.detail || 'Error');
     chatAnswer.textContent = data.answer;
+    outputVideo.style.display = 'none';
     chatVideo.src = `/outputs/${data.video}`;
     chatVideo.style.display = 'block';
     chatVideo.play();
     chatVideo.onended = () => {
       chatVideo.style.display = 'none';
+      outputVideo.style.display = 'block';
       outputVideo.play();
     };
   } catch (err) {
     alert('Chat failed: ' + err.message);
+    outputVideo.style.display = 'block';
     outputVideo.play();
   }
 };


### PR DESCRIPTION
## Summary
- Show chat answers using the same avatar video element
- Overlay chat video in avatar box instead of separate player

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `node --check static/main.js`


------
https://chatgpt.com/codex/tasks/task_e_688ff7a7787483318950708aabd06698