### PR TITLE
Use single avatar video for chat responses

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -23,7 +23,7 @@
       position: relative;
       background: black;
     }
-    #slidesVideo, #outputVideo {
+    #slidesVideo, #outputVideo, #chatVideo {
       width: 100%;
       height: 100%;
     }
@@ -76,6 +76,7 @@
       <div id="avatarBox">
         <img id="avatarFrame" style="width:100%;height:100%;object-fit:contain"/>
         <video id="outputVideo" style="display:none" controls></video>
+        <video id="chatVideo" style="display:none" controls></video>
       </div>
       <div id="controls">
         <label>Slides video:
@@ -100,7 +101,6 @@
         <textarea id="chatInput" rows="3" placeholder="Ask a question..."></textarea>
         <button id="chatBtn">Ask GPT</button>
         <div id="chatAnswer"></div>
-        <video id="chatVideo" style="display:none" controls></video>
       </div>
     </div>
   </div>

--- a/static/main.js
+++ b/static/main.js
@@ -125,12 +125,15 @@ document.getElementById('streamBtn').onclick = () => {
 };
 
 chatBtn.onclick = async () => {
-  if (!currentId) {
-    alert('Upload files first.');
+  if (!currentId || chatBtn.disabled) {
+    if (!currentId) alert('Upload files first.');
     return;
   }
   const question = chatInput.value.trim();
   if (!question) return;
+
+  chatBtn.disabled = true;
+  chatInput.value = '';
 
   outputVideo.pause();
   slidesVideo.pause();
@@ -156,15 +159,20 @@ chatBtn.onclick = async () => {
     const data = await res.json();
     if (!res.ok) throw new Error(data.detail || 'Error');
     chatAnswer.textContent = data.answer;
+    outputVideo.style.display = 'none';
     chatVideo.src = `/outputs/${data.video}`;
     chatVideo.style.display = 'block';
     chatVideo.play();
     chatVideo.onended = () => {
       chatVideo.style.display = 'none';
+      outputVideo.style.display = 'block';
       outputVideo.play();
+      chatBtn.disabled = false;
     };
   } catch (err) {
     alert('Chat failed: ' + err.message);
+    outputVideo.style.display = 'block';
     outputVideo.play();
+    chatBtn.disabled = false;
   }
 };


### PR DESCRIPTION
## Summary
- Show chat answers using the same avatar video element
- Overlay chat video in avatar box instead of separate player
- Allow multiple chat questions by re-enabling Ask button after responses

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `node --check static/main.js`


------
https://chatgpt.com/codex/tasks/task_e_688ff7a7787483318950708aabd06698