### PR TITLE
Use single avatar video for chat responses

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,16 +13,15 @@ WORKDIR /app
 ENV PYTHONPATH="/app"
 
 # Install your app dependencies
-WORKDIR /app
 COPY requirements.txt .
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir --root-user-action=ignore -r requirements.txt
 
 RUN mkdir -p uploads outputs
 
 # Copy your FastAPI app and frontend files
 COPY app ./app
 COPY static ./static
-COPY uploads ./uploads
 
 # Start FastAPI app using uvicorn
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/static/index.html
+++ b/static/index.html
@@ -23,7 +23,7 @@
       position: relative;
       background: black;
     }
-    #slidesVideo, #outputVideo {
+    #slidesVideo, #outputVideo, #chatVideo {
       width: 100%;
       height: 100%;
     }
@@ -76,6 +76,7 @@
       <div id="avatarBox">
         <img id="avatarFrame" style="width:100%;height:100%;object-fit:contain"/>
         <video id="outputVideo" style="display:none" controls></video>
+        <video id="chatVideo" style="display:none" controls></video>
       </div>
       <div id="controls">
         <label>Slides video:
@@ -100,7 +101,6 @@
         <textarea id="chatInput" rows="3" placeholder="Ask a question..."></textarea>
         <button id="chatBtn">Ask GPT</button>
         <div id="chatAnswer"></div>
-        <video id="chatVideo" style="display:none" controls></video>
       </div>
     </div>
   </div>

--- a/static/main.js
+++ b/static/main.js
@@ -125,12 +125,15 @@ document.getElementById('streamBtn').onclick = () => {
 };
 
 chatBtn.onclick = async () => {
-  if (!currentId) {
-    alert('Upload files first.');
+  if (!currentId || chatBtn.disabled) {
+    if (!currentId) alert('Upload files first.');
     return;
   }
   const question = chatInput.value.trim();
   if (!question) return;
+
+  chatBtn.disabled = true;
+  chatInput.value = '';
 
   outputVideo.pause();
   slidesVideo.pause();
@@ -156,15 +159,20 @@ chatBtn.onclick = async () => {
     const data = await res.json();
     if (!res.ok) throw new Error(data.detail || 'Error');
     chatAnswer.textContent = data.answer;
+    outputVideo.style.display = 'none';
     chatVideo.src = `/outputs/${data.video}`;
     chatVideo.style.display = 'block';
     chatVideo.play();
     chatVideo.onended = () => {
       chatVideo.style.display = 'none';
+      outputVideo.style.display = 'block';
       outputVideo.play();
+      chatBtn.disabled = false;
     };
   } catch (err) {
     alert('Chat failed: ' + err.message);
+    outputVideo.style.display = 'block';
     outputVideo.play();
+    chatBtn.disabled = false;
   }
 };


### PR DESCRIPTION
## Summary
- Show chat answers using the same avatar video element
- Overlay chat video in avatar box instead of separate player
- Allow multiple chat questions by re-enabling Ask button after responses
- Fix Dockerfile build by creating runtime folders and upgrading pip instead of copying ignored directories

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `node --check static/main.js`
- `docker build -t cl-ai-mvp-test .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?)*

------
https://chatgpt.com/codex/tasks/task_e_688ff7a7787483318950708aabd06698