### PR TITLE
feat: add default class and split upload page

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -79,20 +79,7 @@
         <video id="chatVideo" style="display:none" controls></video>
       </div>
       <div id="controls">
-        <label>Slides video:
-          <input id="videoFile" type="file" accept="video/mp4" />
-        </label>
-        <label>Audio narration:
-          <input id="audioFile" type="file" accept="audio/*" />
-        </label>
-        <label>Timestamps JSON:
-          <input id="timeFile" type="file" accept=".json" />
-        </label>
-        <label>Avatar image/video:
-          <input id="avatarFile" type="file" accept="image/*,video/mp4" />
-        </label>
-        <button id="uploadBtn">Upload & Generate Avatar</button>
-        <button id="streamBtn">Start Real-Time</button>
+        <a href="/upload">Upload new class</a>
         <div id="playbackControls">
           <button id="backBtn">&#9664;&#9664; 5s</button>
           <button id="playPauseBtn">Play</button>

--- a/static/main.js
+++ b/static/main.js
@@ -13,6 +13,48 @@ const chatVideo = document.getElementById('chatVideo');
 let timestamps = [];
 let currentId = null;
 
+function startStreaming() {
+  if (!currentId) return;
+  const ws = new WebSocket(`ws://${location.host}/ws/avatar/${currentId}`);
+  avatarFrame.style.display = 'block';
+  outputVideo.style.display = 'none';
+
+  ws.onmessage = ev => {
+    if (ev.data.startsWith('RESULT::')) {
+      outputVideo.src = `/outputs/${ev.data.substring(8)}`;
+      outputVideo.style.display = 'block';
+      avatarFrame.style.display = 'none';
+      outputVideo.play();
+    } else {
+      avatarFrame.src = 'data:image/jpeg;base64,' + ev.data;
+    }
+  };
+  ws.onclose = () => console.log('stream closed');
+}
+
+async function loadInitial() {
+  const params = new URLSearchParams(window.location.search);
+  currentId = params.get('id') || 'default';
+
+  outputVideo.src = `/outputs/${currentId}.mp4`;
+  slidesVideo.src = `/uploads/${currentId}_slides.mp4`;
+  try {
+    const res = await fetch(`/uploads/${currentId}_timestamps.json`);
+    timestamps = await res.json();
+  } catch {
+    timestamps = [];
+  }
+
+  outputVideo.style.display = 'block';
+  avatarFrame.style.display = 'none';
+  outputVideo.load();
+  slidesVideo.load();
+
+  startStreaming();
+}
+
+window.addEventListener('load', loadInitial);
+
 playPauseBtn.onclick = () => {
   if (outputVideo.paused) {
     outputVideo.play();
@@ -32,54 +74,6 @@ forwardBtn.onclick = () => {
   const newTime = Math.min(dur, outputVideo.currentTime + 5);
   outputVideo.currentTime = newTime;
   slidesVideo.currentTime = newTime;
-};
-
-document.getElementById('uploadBtn').onclick = async () => {
-  const videoFile = document.getElementById('videoFile').files[0];
-  const audioFile = document.getElementById('audioFile').files[0];
-  const timeFile = document.getElementById('timeFile').files[0];
-  const avatarFile = document.getElementById('avatarFile').files[0];
-
-  if (!videoFile || !audioFile || !timeFile || !avatarFile) {
-    alert('Please select slides, audio, timestamps and avatar files.');
-    return;
-  }
-
-  const formData = new FormData();
-  formData.append('video', videoFile);
-  formData.append('audio', audioFile);
-  formData.append('timestamps', timeFile);
-  formData.append('avatar', avatarFile);
-
-  try {
-    const res = await fetch('/upload', { method: 'POST', body: formData });
-    if (!res.ok) {
-      const t = await res.text();
-      throw new Error(`Upload failed: ${res.status} - ${t}`);
-    }
-    const data = await res.json();
-    if (data.error || data.detail) {
-      throw new Error(data.error || data.detail);
-    }
-
-    if (!data.output_video || !data.slides_video) {
-      throw new Error('Server did not return expected file paths');
-    }
-
-    currentId = data.id;
-    outputVideo.src = `/outputs/${data.output_video}`;
-    slidesVideo.src = `/uploads/${data.slides_video}`;
-    const jsonText = await timeFile.text();
-    timestamps = JSON.parse(jsonText);
-    outputVideo.style.display = 'block';
-    avatarFrame.style.display = 'none';
-    outputVideo.load();
-    slidesVideo.load();
-  } catch (err) {
-    console.error('Upload error:', err);
-    alert('Failed to generate video: ' + (err.message || err));
-
-  }
 };
 
 outputVideo.onplay = () => {
@@ -102,31 +96,8 @@ outputVideo.ontimeupdate = () => {
   slideInfo.textContent = `Slide ${idx + 1}`;
 };
 
-document.getElementById('streamBtn').onclick = () => {
-  if (!currentId) {
-    alert('Upload files first.');
-    return;
-  }
-  const ws = new WebSocket(`ws://${location.host}/ws/avatar/${currentId}`);
-  avatarFrame.style.display = 'block';
-  outputVideo.style.display = 'none';
-
-  ws.onmessage = ev => {
-    if (ev.data.startsWith('RESULT::')) {
-      outputVideo.src = `/outputs/${ev.data.substring(8)}`;
-      outputVideo.style.display = 'block';
-      avatarFrame.style.display = 'none';
-      outputVideo.play();
-    } else {
-      avatarFrame.src = 'data:image/jpeg;base64,' + ev.data;
-    }
-  };
-  ws.onclose = () => console.log('stream closed');
-};
-
 chatBtn.onclick = async () => {
   if (!currentId || chatBtn.disabled) {
-    if (!currentId) alert('Upload files first.');
     return;
   }
   const question = chatInput.value.trim();
@@ -176,3 +147,4 @@ chatBtn.onclick = async () => {
     chatBtn.disabled = false;
   }
 };
+

--- a/static/upload.html
+++ b/static/upload.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Upload Class</title>
+  <style>
+    body { font-family: sans-serif; padding: 20px; }
+    label { display: block; margin-bottom: 10px; }
+    button { padding: 8px 12px; background: #2563eb; color: #fff; border: none; border-radius: 4px; cursor: pointer; }
+  </style>
+</head>
+<body>
+  <h1>Upload Class Assets</h1>
+  <label>Slides video:
+    <input id="videoFile" type="file" accept="video/mp4" />
+  </label>
+  <label>Audio narration:
+    <input id="audioFile" type="file" accept="audio/*" />
+  </label>
+  <label>Timestamps JSON:
+    <input id="timeFile" type="file" accept=".json" />
+  </label>
+  <label>Avatar image/video:
+    <input id="avatarFile" type="file" accept="image/*,video/mp4" />
+  </label>
+  <button id="uploadBtn">Upload & Generate Avatar</button>
+  <p id="status"></p>
+  <script src="/static/upload.js"></script>
+</body>
+</html>
+

--- a/static/upload.js
+++ b/static/upload.js
@@ -1,0 +1,32 @@
+const status = document.getElementById('status');
+
+document.getElementById('uploadBtn').onclick = async () => {
+  const videoFile = document.getElementById('videoFile').files[0];
+  const audioFile = document.getElementById('audioFile').files[0];
+  const timeFile = document.getElementById('timeFile').files[0];
+  const avatarFile = document.getElementById('avatarFile').files[0];
+
+  if (!videoFile || !audioFile || !timeFile || !avatarFile) {
+    alert('Please select slides, audio, timestamps and avatar files.');
+    return;
+  }
+
+  const formData = new FormData();
+  formData.append('video', videoFile);
+  formData.append('audio', audioFile);
+  formData.append('timestamps', timeFile);
+  formData.append('avatar', avatarFile);
+
+  status.textContent = 'Uploading...';
+
+  try {
+    const res = await fetch('/upload', { method: 'POST', body: formData });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.detail || 'Upload failed');
+    status.textContent = 'Success! Redirecting...';
+    window.location.href = `/?id=${data.id}`;
+  } catch (err) {
+    status.textContent = 'Error: ' + err.message;
+  }
+};
+


### PR DESCRIPTION
## Summary
- pre-generate a demo class from bundled inputs and serve a dedicated upload page
- simplify viewer page to auto-load the demo or uploaded class and start real-time streaming
- add standalone upload HTML/JS for submitting new assets

## Testing
- `python -m py_compile app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68994dd9494c8331a2e4d1fa43676823