### PR TITLE
feat: add default class and split upload page

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -2,28 +2,40 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <title>MuseTalk Avatar App</title>
+  <title>Virtual Classroom</title>
   <style>
     body {
       margin: 0;
       font-family: sans-serif;
-      background: #f4f6fa;
+      background: #e8e5d1;
+    }
+    header {
+      background: #3f51b5;
+      color: #fff;
+      padding: 10px 20px;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
     }
     #root {
       display: flex;
       flex-direction: column;
-      height: 100vh;
+      height: calc(100vh - 60px);
     }
     #playerRow {
       display: flex;
       flex: 1;
+      padding: 10px;
+      gap: 10px;
     }
     #slidesBox, #avatarBox {
       flex: 1;
       position: relative;
-      background: black;
+      background: #2e7d32;
+      border: 8px solid #bfa27a;
+      border-radius: 8px;
     }
-    #slidesVideo, #outputVideo, #chatVideo {
+    #slidesVideo, #outputVideo, #chatVideo, #avatarFrame {
       width: 100%;
       height: 100%;
     }
@@ -32,7 +44,7 @@
       top: 10px;
       left: 10px;
       padding: 4px 8px;
-      background: rgba(0, 0, 0, 0.7);
+      background: rgba(0, 0, 0, 0.6);
       color: #fff;
       border-radius: 4px;
       font-size: 14px;
@@ -44,11 +56,8 @@
       display: flex;
       flex-direction: column;
       gap: 12px;
-    }
-    input[type=file] {
-      border: 1px solid #aaa;
-      padding: 4px;
-      border-radius: 4px;
+      background: #fff;
+      border-radius: 8px;
     }
     button {
       padding: 8px 12px;
@@ -67,6 +76,10 @@
   </style>
 </head>
 <body>
+  <header>
+    <h2>Virtual Classroom</h2>
+    <button id="uploadBtn">Upload Class</button>
+  </header>
   <div id="root">
     <div id="playerRow">
       <div id="slidesBox">
@@ -74,25 +87,11 @@
         <div id="slideInfo">Slide 0</div>
       </div>
       <div id="avatarBox">
-        <img id="avatarFrame" style="width:100%;height:100%;object-fit:contain"/>
-        <video id="outputVideo" style="display:none" controls></video>
+        <img id="avatarFrame" style="display:none;object-fit:contain"/>
+        <video id="outputVideo" controls></video>
         <video id="chatVideo" style="display:none" controls></video>
       </div>
       <div id="controls">
-        <label>Slides video:
-          <input id="videoFile" type="file" accept="video/mp4" />
-        </label>
-        <label>Audio narration:
-          <input id="audioFile" type="file" accept="audio/*" />
-        </label>
-        <label>Timestamps JSON:
-          <input id="timeFile" type="file" accept=".json" />
-        </label>
-        <label>Avatar image/video:
-          <input id="avatarFile" type="file" accept="image/*,video/mp4" />
-        </label>
-        <button id="uploadBtn">Upload & Generate Avatar</button>
-        <button id="streamBtn">Start Real-Time</button>
         <div id="playbackControls">
           <button id="backBtn">&#9664;&#9664; 5s</button>
           <button id="playPauseBtn">Play</button>

--- a/static/upload.html
+++ b/static/upload.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Upload Class</title>
+  <style>
+    body { font-family: sans-serif; margin:0; background: #e8e5d1; }
+    header {
+      background: #3f51b5;
+      color: #fff;
+      padding: 10px 20px;
+      display:flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+    main { padding: 20px; }
+    label { display: block; margin-bottom: 10px; }
+    button { padding: 8px 12px; background: #2563eb; color: #fff; border: none; border-radius: 4px; cursor: pointer; }
+  </style>
+</head>
+<body>
+  <header>
+    <h2>Upload Class</h2>
+    <button onclick="window.location.href='/'">Back</button>
+  </header>
+  <main>
+    <label>Slides video:
+      <input id="videoFile" type="file" accept="video/mp4" />
+    </label>
+    <label>Audio narration:
+      <input id="audioFile" type="file" accept="audio/*" />
+    </label>
+    <label>Timestamps JSON:
+      <input id="timeFile" type="file" accept=".json" />
+    </label>
+    <label>Avatar image/video:
+      <input id="avatarFile" type="file" accept="image/*,video/mp4" />
+    </label>
+    <button id="uploadBtn">Upload & Generate Avatar</button>
+    <p id="status"></p>
+  </main>
+  <script src="/static/upload.js"></script>
+</body>
+</html>
+

--- a/static/upload.js
+++ b/static/upload.js
@@ -1,0 +1,32 @@
+const status = document.getElementById('status');
+
+document.getElementById('uploadBtn').onclick = async () => {
+  const videoFile = document.getElementById('videoFile').files[0];
+  const audioFile = document.getElementById('audioFile').files[0];
+  const timeFile = document.getElementById('timeFile').files[0];
+  const avatarFile = document.getElementById('avatarFile').files[0];
+
+  if (!videoFile || !audioFile || !timeFile || !avatarFile) {
+    alert('Please select slides, audio, timestamps and avatar files.');
+    return;
+  }
+
+  const formData = new FormData();
+  formData.append('video', videoFile);
+  formData.append('audio', audioFile);
+  formData.append('timestamps', timeFile);
+  formData.append('avatar', avatarFile);
+
+  status.textContent = 'Uploading...';
+
+  try {
+    const res = await fetch('/upload', { method: 'POST', body: formData });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.detail || 'Upload failed');
+    status.textContent = 'Success! Redirecting...';
+    window.location.href = `/?id=${data.id}`;
+  } catch (err) {
+    status.textContent = 'Error: ' + err.message;
+  }
+};
+


### PR DESCRIPTION
## Summary
- pre-generate a demo class from bundled inputs and serve a dedicated upload page
- simplify viewer page to auto-load the demo or uploaded class and start real-time streaming
- polish classroom-themed UI and ensure avatar video is visible with a prominent upload button

## Testing
- `python -m py_compile app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68994dd9494c8331a2e4d1fa43676823