### PR TITLE
Add VTutor chat demo using iframe avatar

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,11 @@ will query GPT, synthesise audio using ``gTTS`` and generate a short video of
 the avatar speaking the answer. After playback finishes, the lesson resumes
 automatically.
 
+## VTutor Chat Demo
+
+For a lightweight chat experience that speaks answers live in the browser, a
+VTutor iframe has been added. Start the server and visit
+`http://localhost:8080/vtutor` to try it. Enter a question and the backend will
+generate a GPT response which is sent to the VTutor avatar via `postMessage`
+for speech synthesis.
+

--- a/static/vtutor.html
+++ b/static/vtutor.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>VTutor Chat Demo</title>
+  <style>
+    body {
+      font-family: sans-serif;
+      margin: 0;
+      padding: 20px;
+      background: #f4f6fa;
+    }
+    .unity-frame {
+      width: 400px;
+      height: 400px;
+      border: none;
+      display: block;
+      margin: 0 auto;
+    }
+    #chat {
+      margin-top: 20px;
+      display: flex;
+      gap: 8px;
+      justify-content: center;
+    }
+    #question {
+      flex: 1;
+      padding: 8px;
+    }
+    #askBtn {
+      padding: 8px 12px;
+    }
+    #answer {
+      margin-top: 12px;
+      text-align: center;
+    }
+  </style>
+</head>
+<body>
+  <iframe src="http://full.iframe.sdk.vtutor.tools" id="unity-iframe" class="unity-frame"></iframe>
+  <div id="chat">
+    <input id="question" type="text" placeholder="Ask a question" />
+    <button id="askBtn">Ask</button>
+  </div>
+  <div id="answer"></div>
+  <script src="/static/vtutor.js"></script>
+</body>
+</html>

--- a/static/vtutor.js
+++ b/static/vtutor.js
@@ -1,0 +1,23 @@
+const unityIframe = document.getElementById('unity-iframe');
+const questionInput = document.getElementById('question');
+const askBtn = document.getElementById('askBtn');
+const answerDiv = document.getElementById('answer');
+
+askBtn.onclick = async () => {
+  const question = questionInput.value.trim();
+  if (!question) return;
+
+  try {
+    const res = await fetch('/vtutor_chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ question })
+    });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.detail || 'Error');
+    answerDiv.textContent = data.answer;
+    unityIframe.contentWindow.postMessage({ action: 'unitySpeak', message: data.answer }, '*');
+  } catch (err) {
+    alert('Chat failed: ' + err.message);
+  }
+};


### PR DESCRIPTION
## Summary
- Serve a new `/vtutor` page embedding the VTutor iframe
- Add `/vtutor_chat` endpoint returning GPT responses for live speech
- Provide frontend HTML/JS to send questions and relay answers to the avatar

## Testing
- `python -m py_compile app/main.py`
- `node --check static/vtutor.js`


------
https://chatgpt.com/codex/tasks/task_e_6899748796808331a603d1121b410149