### PR TITLE
feat: integrate google slides and manual navigation

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -4,6 +4,7 @@ from fastapi import (
     WebSocket,
     WebSocketDisconnect,
     HTTPException,
+    Form,
 )
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
@@ -11,6 +12,7 @@ from fastapi.middleware.cors import CORSMiddleware
 import uuid
 import os
 import asyncio
+import shutil
 
 import openai
 from gtts import gTTS
@@ -44,26 +46,79 @@ app.mount("/static", StaticFiles(directory="static"), name="static")
 app.mount("/uploads", StaticFiles(directory="uploads"), name="uploads")
 app.mount("/outputs", StaticFiles(directory="outputs"), name="outputs")
 
+
+# Prepare a default class from bundled input assets
+DEFAULT_ID = "default"
+
+
+def _prepare_default_class() -> None:
+    """Copy demo assets into place and pre-generate the default avatar."""
+
+    os.makedirs("uploads", exist_ok=True)
+    os.makedirs("outputs", exist_ok=True)
+
+    src_dir = "inputs"
+    src_audio = os.path.join(src_dir, "audio.wav")
+    src_ts = os.path.join(src_dir, "timestamps.json")
+    src_avatar = os.path.join(src_dir, "avatar1.mp4")
+    src_slides_id = os.path.join(src_dir, "slides_id.txt")
+    dst_audio = os.path.join("uploads", f"{DEFAULT_ID}_audio.wav")
+    dst_ts = os.path.join("uploads", f"{DEFAULT_ID}_timestamps.json")
+    dst_avatar = os.path.join("uploads", f"{DEFAULT_ID}_avatar.mp4")
+    dst_slides_id = os.path.join("uploads", f"{DEFAULT_ID}_slides_id.txt")
+
+    try:
+        shutil.copyfile(src_audio, dst_audio)
+        shutil.copyfile(src_ts, dst_ts)
+        shutil.copyfile(src_avatar, dst_avatar)
+        shutil.copyfile(src_slides_id, dst_slides_id)
+    except FileNotFoundError:
+        # If any demo asset is missing, simply skip generation
+        return
+
+    output_path = os.path.join("outputs", f"{DEFAULT_ID}.mp4")
+    if not os.path.exists(output_path):
+        try:
+            run_musetalk(dst_audio, dst_avatar, output_path)
+        except Exception as exc:  # best-effort
+            print(f"Failed to generate default class: {exc}")
+
+
+_prepare_default_class()
+
 @app.get("/")
 def index():
     return FileResponse("static/index.html")
 
+
+@app.get("/upload")
+def upload_page():
+    return FileResponse("static/upload.html")
+
 @app.post("/upload")
-async def upload(video: UploadFile, audio: UploadFile, timestamps: UploadFile, avatar: UploadFile):
+async def upload(
+    audio: UploadFile,
+    timestamps: UploadFile,
+    avatar: UploadFile,
+    slides_id: str = Form(...),
+):
     uid = uuid.uuid4().hex
     os.makedirs("uploads", exist_ok=True)
     os.makedirs("outputs", exist_ok=True)
 
     # Save all uploaded files
     paths = {
-        "slides": os.path.join("uploads", f"{uid}_slides.mp4"),
         "audio": os.path.join("uploads", f"{uid}_audio.wav"),
         "timestamps": os.path.join("uploads", f"{uid}_timestamps.json"),
         "avatar": os.path.join("uploads", f"{uid}_avatar{os.path.splitext(avatar.filename)[1] or '.mp4'}"),
     }
-    for file, path in zip([video, audio, timestamps, avatar], paths.values()):
+    for file, path in zip([audio, timestamps, avatar], paths.values()):
         with open(path, "wb") as f:
             f.write(await file.read())
+
+    # Save slides presentation id
+    with open(os.path.join("uploads", f"{uid}_slides_id.txt"), "w") as f:
+        f.write(slides_id.strip())
 
     # Generate avatar video in a thread so the event loop is not blocked
     output_path = os.path.join("outputs", f"{uid}.mp4")
@@ -78,8 +133,7 @@ async def upload(video: UploadFile, audio: UploadFile, timestamps: UploadFile, a
     return {
         "id": uid,
         "output_video": f"{uid}.mp4",
-        "slides_video": os.path.basename(paths["slides"]),
-        "timestamps": os.path.basename(paths["timestamps"])
+        "timestamps": os.path.basename(paths["timestamps"]),
     }
 
 

--- a/inputs/slides_id.txt
+++ b/inputs/slides_id.txt
@@ -1,0 +1,1 @@
+presentation-id-placeholder

--- a/static/index.html
+++ b/static/index.html
@@ -2,28 +2,47 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <title>MuseTalk Avatar App</title>
+  <title>Virtual Classroom</title>
   <style>
     body {
       margin: 0;
       font-family: sans-serif;
-      background: #f4f6fa;
+      background: #e8e5d1;
+    }
+    header {
+      background: #3f51b5;
+      color: #fff;
+      padding: 10px 20px;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
     }
     #root {
       display: flex;
       flex-direction: column;
-      height: 100vh;
+      height: calc(100vh - 60px);
     }
     #playerRow {
       display: flex;
       flex: 1;
+      padding: 10px;
+      gap: 10px;
     }
-    #slidesBox, #avatarBox {
+    #slidesBox {
+      flex: 2;
+      position: relative;
+      background: #2e7d32;
+      border: 8px solid #bfa27a;
+      border-radius: 8px;
+    }
+    #avatarBox {
       flex: 1;
       position: relative;
-      background: black;
+      background: #2e7d32;
+      border: 8px solid #bfa27a;
+      border-radius: 8px;
     }
-    #slidesVideo, #outputVideo, #chatVideo {
+    #slideImg, #outputVideo, #chatVideo, #avatarFrame {
       width: 100%;
       height: 100%;
     }
@@ -32,7 +51,7 @@
       top: 10px;
       left: 10px;
       padding: 4px 8px;
-      background: rgba(0, 0, 0, 0.7);
+      background: rgba(0, 0, 0, 0.6);
       color: #fff;
       border-radius: 4px;
       font-size: 14px;
@@ -44,11 +63,8 @@
       display: flex;
       flex-direction: column;
       gap: 12px;
-    }
-    input[type=file] {
-      border: 1px solid #aaa;
-      padding: 4px;
-      border-radius: 4px;
+      background: #fff;
+      border-radius: 8px;
     }
     button {
       padding: 8px 12px;
@@ -59,7 +75,7 @@
       font-weight: 600;
       cursor: pointer;
     }
-    #playbackControls {
+    #navControls {
       display: flex;
       gap: 8px;
       margin-top: 8px;
@@ -67,36 +83,26 @@
   </style>
 </head>
 <body>
+  <header>
+    <h2>Virtual Classroom</h2>
+    <button id="uploadBtn">Upload Class</button>
+  </header>
   <div id="root">
     <div id="playerRow">
       <div id="slidesBox">
-        <video id="slidesVideo" muted controls></video>
+        <img id="slideImg" alt="Slide"/>
         <div id="slideInfo">Slide 0</div>
       </div>
       <div id="avatarBox">
-        <img id="avatarFrame" style="width:100%;height:100%;object-fit:contain"/>
-        <video id="outputVideo" style="display:none" controls></video>
+        <img id="avatarFrame" style="display:none;object-fit:contain"/>
+        <video id="outputVideo" controls></video>
         <video id="chatVideo" style="display:none" controls></video>
       </div>
       <div id="controls">
-        <label>Slides video:
-          <input id="videoFile" type="file" accept="video/mp4" />
-        </label>
-        <label>Audio narration:
-          <input id="audioFile" type="file" accept="audio/*" />
-        </label>
-        <label>Timestamps JSON:
-          <input id="timeFile" type="file" accept=".json" />
-        </label>
-        <label>Avatar image/video:
-          <input id="avatarFile" type="file" accept="image/*,video/mp4" />
-        </label>
-        <button id="uploadBtn">Upload & Generate Avatar</button>
-        <button id="streamBtn">Start Real-Time</button>
-        <div id="playbackControls">
-          <button id="backBtn">&#9664;&#9664; 5s</button>
+        <div id="navControls">
+          <button id="prevSlide">Prev Slide</button>
+          <button id="nextSlide">Next Slide</button>
           <button id="playPauseBtn">Play</button>
-          <button id="forwardBtn">5s &#9654;&#9654;</button>
         </div>
         <textarea id="chatInput" rows="3" placeholder="Ask a question..."></textarea>
         <button id="chatBtn">Ask GPT</button>

--- a/static/upload.html
+++ b/static/upload.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Upload Class</title>
+  <style>
+    body { font-family: sans-serif; margin:0; background: #e8e5d1; }
+    header {
+      background: #3f51b5;
+      color: #fff;
+      padding: 10px 20px;
+      display:flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+    main { padding: 20px; }
+    label { display: block; margin-bottom: 10px; }
+    button { padding: 8px 12px; background: #2563eb; color: #fff; border: none; border-radius: 4px; cursor: pointer; }
+  </style>
+</head>
+<body>
+  <header>
+    <h2>Upload Class</h2>
+    <button onclick="window.location.href='/'">Back</button>
+  </header>
+  <main>
+    <label>Google Slides URL or ID:
+      <input id="slidesId" type="text" />
+    </label>
+    <label>Audio narration:
+      <input id="audioFile" type="file" accept="audio/*" />
+    </label>
+    <label>Timestamps JSON:
+      <input id="timeFile" type="file" accept=".json" />
+    </label>
+    <label>Avatar image/video:
+      <input id="avatarFile" type="file" accept="image/*,video/mp4" />
+    </label>
+    <button id="uploadBtn">Upload & Generate Avatar</button>
+    <p id="status"></p>
+  </main>
+  <script src="/static/upload.js"></script>
+</body>
+</html>
+

--- a/static/upload.js
+++ b/static/upload.js
@@ -1,0 +1,32 @@
+const status = document.getElementById('status');
+
+document.getElementById('uploadBtn').onclick = async () => {
+  const slidesId = document.getElementById('slidesId').value.trim();
+  const audioFile = document.getElementById('audioFile').files[0];
+  const timeFile = document.getElementById('timeFile').files[0];
+  const avatarFile = document.getElementById('avatarFile').files[0];
+
+  if (!slidesId || !audioFile || !timeFile || !avatarFile) {
+    alert('Please provide slides ID, audio, timestamps and avatar files.');
+    return;
+  }
+
+  const formData = new FormData();
+  formData.append('slides_id', slidesId);
+  formData.append('audio', audioFile);
+  formData.append('timestamps', timeFile);
+  formData.append('avatar', avatarFile);
+
+  status.textContent = 'Uploading...';
+
+  try {
+    const res = await fetch('/upload', { method: 'POST', body: formData });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.detail || 'Upload failed');
+    status.textContent = 'Success! Redirecting...';
+    window.location.href = `/?id=${data.id}`;
+  } catch (err) {
+    status.textContent = 'Error: ' + err.message;
+  }
+};
+


### PR DESCRIPTION
## Summary
- replace slide video with Google Slides thumbnails and larger slide area
- navigate slides manually and sync avatar/audio playback to timestamped segments
- allow uploads to reference a Google Slides presentation by ID

## Testing
- `python -m py_compile app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68994dd9494c8331a2e4d1fa43676823