### PR TITLE
Allow Cloud Run to set port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,7 @@ COPY static ./static
 COPY inputs ./inputs
 
 # Start FastAPI app using uvicorn
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080"]
+# Allow Cloud Run to supply the port via the PORT env variable.
+# Default to 8080 for local development.
+EXPOSE 8080
+CMD ["sh", "-c", "uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8080}"]


### PR DESCRIPTION
## Summary
- Listen on the port provided by Cloud Run with a default of 8080
- Expose port 8080 for local development

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689a357b3c448331bc7dbf7abc2d29a9