### PR TITLE
Prepare default assets asynchronously

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,7 @@ COPY static ./static
 COPY inputs ./inputs
 
 # Start FastAPI app using uvicorn
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080"]
+# Allow Cloud Run to supply the port via the PORT env variable.
+# Default to 8080 for local development.
+EXPOSE 8080
+CMD ["sh", "-c", "uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8080}"]

--- a/app/main.py
+++ b/app/main.py
@@ -149,7 +149,16 @@ def _prepare_default_class() -> None:
             print(f"Failed to generate default class: {exc}")
 
 
-_prepare_default_class()
+# Prepare default assets in the background so startup is quick
+@app.on_event("startup")
+async def _schedule_default_class() -> None:
+    async def prepare() -> None:
+        try:
+            await asyncio.to_thread(_prepare_default_class)
+        except Exception as exc:  # best-effort
+            print(f"Failed to generate default class: {exc}")
+
+    asyncio.create_task(prepare())
 
 @app.get("/")
 def index():


### PR DESCRIPTION
## Summary
- Generate default demo assets in a background task so Cloud Run can start listening on the provided port immediately

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689a357b3c448331bc7dbf7abc2d29a9