### PR TITLE
feat: add next.js frontend ui

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,11 @@ __pycache__/
 *.pyc
 uploads/
 outputs/
+
+node_modules/
+frontend/node_modules/
+frontend/.next/
+package-lock.json
+
+# Image assets
+*.png

--- a/README.md
+++ b/README.md
@@ -58,3 +58,7 @@ The `inputs/` folder contains `slides.pdf`, `audio.wav`, `timestamps.json` and
 shows a working example. Replace these files with your own before launching the
 server to change the preloaded class.
 
+
+## New Next.js Frontend
+
+A modern React UI is available in the `frontend/` directory. It wraps the existing upload and player flows without changing any API routes. See `frontend/README.md` for setup and integration instructions.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,26 @@
+# CL-AI-MVP Frontend UI
+
+This directory contains a Next.js App Router frontend that provides a modern interface for the existing CL-AI-MVP backend. All original API routes and player/upload flows remain untouched.
+
+## Getting Started
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+## Integration Notes
+
+- `lib/routes.ts` defines `LEGACY_UPLOAD_PATH` and `LEGACY_PLAYER_PATH` constants. Adjust these to match the paths of the current upload page and player.
+- The player wrapper at `/player/[id]` loads the existing player inside an `iframe`. No backend changes are required.
+- The catalog includes a pre-generated **Python Basics** course and a **Design Your Own** flow that links to the legacy uploader.
+- Components are styled with Tailwind CSS and shadcn/ui primitives. Animations use Framer Motion where applicable.
+- All features are front-end only; replace mock data with real API calls as needed.
+
+## Building for Production
+
+```bash
+npm run build
+npm start
+```

--- a/frontend/app/courses/page.tsx
+++ b/frontend/app/courses/page.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useState } from "react";
+import { CourseCard } from "@/components/course-card";
+import { FilterBar } from "@/components/filter-bar";
+import { EmptyState } from "@/components/empty-state";
+
+const COURSES = [
+  {
+    id: "python-basics",
+    title: "Python Basics",
+    description: "Learn the fundamentals of Python programming.",
+    level: "Beginner",
+    duration: "45 min",
+    thumbnail: "https://placehold.co/600x400?text=Python",
+  },
+];
+
+export default function CoursesPage() {
+  const [search, setSearch] = useState("");
+  const [level, setLevel] = useState("");
+
+  const filtered = COURSES.filter(
+    (c) =>
+      c.title.toLowerCase().includes(search.toLowerCase()) &&
+      (level ? c.level === level : true)
+  );
+
+  return (
+    <div className="mx-auto max-w-6xl px-4 py-10">
+      <h1 className="mb-6 text-3xl font-bold">Courses</h1>
+      <FilterBar onSearch={setSearch} onLevel={setLevel} />
+      {filtered.length ? (
+        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {filtered.map((course) => (
+            <CourseCard key={course.id} {...course} />
+          ))}
+        </div>
+      ) : (
+        <EmptyState
+          title="No courses found"
+          description="Try adjusting your search or filters."
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/app/courses/python-basics/page.tsx
+++ b/frontend/app/courses/python-basics/page.tsx
@@ -1,0 +1,41 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { SyllabusList } from "@/components/syllabus-list";
+import { ProgressPill } from "@/components/progress-pill";
+
+const syllabus = [
+  { title: "Introduction", lessons: ["What is Python?", "Installing Python"] },
+  { title: "Basics", lessons: ["Variables", "Control Flow"] },
+];
+
+export default function PythonBasicsPage() {
+  return (
+    <div className="mx-auto max-w-5xl px-4 py-10">
+      <div className="mb-8 rounded-xl bg-indigo-100 p-6">
+        <h1 className="text-3xl font-bold">Python Basics</h1>
+        <p className="mt-2 text-gray-700">
+          Learn the fundamentals of Python programming in this beginner-friendly course.
+        </p>
+        <div className="mt-4 flex items-center gap-4">
+          <Link href="/player/python-basics">
+            <Button>Start Course</Button>
+          </Link>
+          <ProgressPill value={0} />
+        </div>
+      </div>
+      <div className="grid gap-8 md:grid-cols-3">
+        <div className="md:col-span-2">
+          <h2 className="mb-4 text-xl font-semibold">Syllabus</h2>
+          <SyllabusList sections={syllabus} />
+        </div>
+        <div>
+          <h2 className="mb-4 text-xl font-semibold">About this course</h2>
+          <p className="text-sm text-gray-600">
+            A quick introduction to Python covering the basics of syntax,
+            variables, and control flow.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/create/page.tsx
+++ b/frontend/app/create/page.tsx
@@ -1,0 +1,32 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Stepper } from "@/components/stepper";
+import { LEGACY_UPLOAD_PATH } from "@/lib/routes";
+
+const steps = [
+  { title: "Prepare files", description: "Slides, audio, timestamps, avatar" },
+  { title: "Upload", description: "Generate your lesson" },
+];
+
+export default function CreatePage() {
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-10">
+      <h1 className="mb-6 text-3xl font-bold">Design Your Own</h1>
+      <p className="mb-8 text-gray-700">
+        Upload your slides, audio, and timestamps to generate your lesson.
+      </p>
+      <Stepper steps={steps} current={0} />
+      <ul className="mt-6 list-disc space-y-2 pl-6 text-sm text-gray-700">
+        <li>Slides PDF or Google Slides ID</li>
+        <li>Audio narration</li>
+        <li>Timestamps JSON</li>
+        <li>Avatar image/video (optional)</li>
+      </ul>
+      <div className="mt-10 flex justify-end">
+        <Link href={LEGACY_UPLOAD_PATH}>
+          <Button>Go to Upload</Button>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+html, body, :root {
+  height: 100%;
+}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,0 +1,25 @@
+import "./globals.css";
+import { AppHeader } from "@/components/app-header";
+import { Footer } from "@/components/footer";
+
+export const metadata = {
+  title: "CL-AI-MVP",
+  description:
+    "Learn from ready-made courses or build your own AI-powered lessons",
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body className="flex min-h-screen flex-col bg-neutral-50 font-sans">
+        <AppHeader />
+        <main className="flex-1">{children}</main>
+        <Footer />
+      </body>
+    </html>
+  );
+}

--- a/frontend/app/library/page.tsx
+++ b/frontend/app/library/page.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { CourseCard } from "@/components/course-card";
+import { EmptyState } from "@/components/empty-state";
+import { Button } from "@/components/ui/button";
+
+interface LibraryCourse {
+  id: string;
+  title: string;
+  description: string;
+  level: string;
+  duration: string;
+  thumbnail?: string;
+}
+
+export default function LibraryPage() {
+  const [courses, setCourses] = useState<LibraryCourse[] | null>(null);
+
+  useEffect(() => {
+    fetch("/api/library")
+      .then((res) => res.json())
+      .then((data) => setCourses(data))
+      .catch(() => setCourses([]));
+  }, []);
+
+  if (courses === null) {
+    return <div className="p-10">Loading...</div>;
+  }
+
+  return (
+    <div className="mx-auto max-w-6xl px-4 py-10">
+      <h1 className="mb-6 text-3xl font-bold">My Library</h1>
+      {courses.length ? (
+        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {courses.map((course) => (
+            <CourseCard key={course.id} {...course} />
+          ))}
+        </div>
+      ) : (
+        <EmptyState
+          title="No courses yet"
+          description="Create your first course to see it here."
+          action={
+            <Link href="/create">
+              <Button>Create a course</Button>
+            </Link>
+          }
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,0 +1,41 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Upload, Play, ArrowRight } from "lucide-react";
+
+export default function HomePage() {
+  return (
+    <section className="mx-auto max-w-4xl px-4 py-20 text-center">
+      <h1 className="text-4xl font-bold">
+        Learn from ready-made courses or build your own AI-powered lessons
+      </h1>
+      <div className="mt-8 flex justify-center gap-4">
+        <Link href="/courses">
+          <Button>Browse Courses</Button>
+        </Link>
+        <Link href="/create">
+          <Button variant="outline">Design Your Own</Button>
+        </Link>
+      </div>
+      <div className="mt-16 grid gap-6 md:grid-cols-3">
+        <Card className="flex flex-col items-center p-6">
+          <Upload className="h-12 w-12 text-brand" />
+          <h3 className="mt-4 font-semibold">Upload</h3>
+          <p className="mt-2 text-sm text-gray-600">Add your slides and audio.</p>
+        </Card>
+        <Card className="flex flex-col items-center p-6">
+          <Play className="h-12 w-12 text-brand" />
+          <h3 className="mt-4 font-semibold">Generate</h3>
+          <p className="mt-2 text-sm text-gray-600">
+            Our AI creates a talking avatar.
+          </p>
+        </Card>
+        <Card className="flex flex-col items-center p-6">
+          <ArrowRight className="h-12 w-12 text-brand" />
+          <h3 className="mt-4 font-semibold">Share</h3>
+          <p className="mt-2 text-sm text-gray-600">Deliver engaging courses.</p>
+        </Card>
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/player/[id]/page.tsx
+++ b/frontend/app/player/[id]/page.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { LEGACY_PLAYER_PATH } from "@/lib/routes";
+
+export default function PlayerPage({ params }: { params: { id: string } }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="flex h-full flex-col">
+      <header className="flex items-center justify-between border-b p-4">
+        <Link href="/courses" className="text-sm text-gray-500">
+          ← Back
+        </Link>
+        <h1 className="font-semibold capitalize">{params.id.replace("-", " ")}</h1>
+        <button
+          className="text-sm text-brand"
+          onClick={() => setOpen(!open)}
+          aria-expanded={open}
+        >
+          Syllabus
+        </button>
+      </header>
+      <div className="flex flex-1 overflow-hidden">
+        <div className="flex-1">
+          <iframe
+            src={`${LEGACY_PLAYER_PATH}/${params.id}`}
+            className="h-full w-full border-0"
+            title="Course Player"
+          />
+        </div>
+        <aside
+          className={`${
+            open ? "block" : "hidden"
+          } w-64 border-l bg-white p-4 md:block`}
+        >
+          <h2 className="mb-2 font-medium">Syllabus</h2>
+          <p className="text-sm text-gray-600">Coming soon...</p>
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/app-header.tsx
+++ b/frontend/components/app-header.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import { Menu } from "lucide-react";
+import { Button } from "./ui/button";
+
+const navItems = [
+  { href: "/courses", label: "Courses" },
+  { href: "/create", label: "Design Your Own" },
+  { href: "/library", label: "My Library" },
+];
+
+export function AppHeader() {
+  const [open, setOpen] = useState(false);
+  return (
+    <header className="border-b bg-white">
+      <div className="mx-auto flex max-w-7xl items-center justify-between p-4">
+        <Link href="/" className="text-xl font-semibold text-brand">
+          CL-AI-MVP
+        </Link>
+        <nav className="hidden gap-6 md:flex">
+          {navItems.map((item) => (
+            <Link
+              key={item.href}
+              href={item.href}
+              className="text-sm font-medium text-gray-700 hover:text-brand"
+            >
+              {item.label}
+            </Link>
+          ))}
+        </nav>
+        <Button
+          variant="ghost"
+          className="md:hidden"
+          onClick={() => setOpen(!open)}
+          aria-label="Toggle Menu"
+        >
+          <Menu className="h-6 w-6" />
+        </Button>
+      </div>
+      {open && (
+        <div className="space-y-2 px-4 pb-4 md:hidden">
+          {navItems.map((item) => (
+            <Link
+              key={item.href}
+              href={item.href}
+              className="block rounded-md p-2 text-sm font-medium hover:bg-brand/10"
+            >
+              {item.label}
+            </Link>
+          ))}
+        </div>
+      )}
+    </header>
+  );
+}

--- a/frontend/components/course-card.tsx
+++ b/frontend/components/course-card.tsx
@@ -1,0 +1,48 @@
+import Link from "next/link";
+import { Card } from "./ui/card";
+import { Button } from "./ui/button";
+
+interface CourseCardProps {
+  id: string;
+  title: string;
+  description: string;
+  level: string;
+  duration: string;
+  thumbnail?: string;
+}
+
+export function CourseCard({
+  id,
+  title,
+  description,
+  level,
+  duration,
+  thumbnail,
+}: CourseCardProps) {
+  return (
+    <Card className="flex flex-col overflow-hidden">
+      {thumbnail && (
+        <img
+          src={thumbnail}
+          alt=""
+          className="h-40 w-full object-cover"
+        />
+      )}
+      <div className="flex flex-1 flex-col p-4">
+        <div className="mb-2 flex items-center justify-between">
+          <h3 className="text-lg font-semibold">{title}</h3>
+          <span className="rounded-full bg-emerald-100 px-2 py-0.5 text-xs text-emerald-700">
+            {level}
+          </span>
+        </div>
+        <p className="flex-1 text-sm text-gray-600">{description}</p>
+        <div className="mt-4 flex items-center justify-between">
+          <span className="text-xs text-gray-500">{duration}</span>
+          <Link href={`/courses/${id}`}>
+            <Button>View</Button>
+          </Link>
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/frontend/components/empty-state.tsx
+++ b/frontend/components/empty-state.tsx
@@ -1,0 +1,17 @@
+import { ReactNode } from "react";
+
+interface EmptyStateProps {
+  title: string;
+  description: string;
+  action?: ReactNode;
+}
+
+export function EmptyState({ title, description, action }: EmptyStateProps) {
+  return (
+    <div className="flex flex-col items-center justify-center py-20 text-center">
+      <p className="text-xl font-semibold">{title}</p>
+      <p className="mt-2 max-w-md text-gray-600">{description}</p>
+      {action && <div className="mt-6">{action}</div>}
+    </div>
+  );
+}

--- a/frontend/components/filter-bar.tsx
+++ b/frontend/components/filter-bar.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+interface FilterBarProps {
+  onSearch: (term: string) => void;
+  onLevel: (level: string) => void;
+}
+
+export function FilterBar({ onSearch, onLevel }: FilterBarProps) {
+  return (
+    <div className="mb-6 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+      <input
+        type="text"
+        placeholder="Search courses"
+        onChange={(e) => onSearch(e.target.value)}
+        className="w-full rounded-md border px-3 py-2 md:w-1/3"
+      />
+      <div className="flex gap-4">
+        <select
+          onChange={(e) => onLevel(e.target.value)}
+          className="rounded-md border px-3 py-2"
+        >
+          <option value="">All Levels</option>
+          <option value="Beginner">Beginner</option>
+          <option value="Intermediate">Intermediate</option>
+          <option value="Advanced">Advanced</option>
+        </select>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/footer.tsx
+++ b/frontend/components/footer.tsx
@@ -1,0 +1,9 @@
+export function Footer() {
+  return (
+    <footer className="border-t bg-white">
+      <div className="mx-auto max-w-7xl p-4 text-center text-sm text-gray-500">
+        © {new Date().getFullYear()} CL-AI-MVP
+      </div>
+    </footer>
+  );
+}

--- a/frontend/components/progress-bar.tsx
+++ b/frontend/components/progress-bar.tsx
@@ -1,0 +1,14 @@
+interface ProgressBarProps {
+  value: number; // 0-100
+}
+
+export function ProgressBar({ value }: ProgressBarProps) {
+  return (
+    <div className="w-full rounded-full bg-gray-200">
+      <div
+        className="h-2 rounded-full bg-brand"
+        style={{ width: `${value}%` }}
+      />
+    </div>
+  );
+}

--- a/frontend/components/progress-pill.tsx
+++ b/frontend/components/progress-pill.tsx
@@ -1,0 +1,11 @@
+interface ProgressPillProps {
+  value: number;
+}
+
+export function ProgressPill({ value }: ProgressPillProps) {
+  return (
+    <span className="inline-block rounded-full bg-brand/10 px-2 py-0.5 text-xs text-brand">
+      {value}% complete
+    </span>
+  );
+}

--- a/frontend/components/stepper.tsx
+++ b/frontend/components/stepper.tsx
@@ -1,0 +1,28 @@
+interface StepperProps {
+  steps: { title: string; description?: string }[];
+  current: number;
+}
+
+export function Stepper({ steps, current }: StepperProps) {
+  return (
+    <ol className="flex flex-col gap-4 md:flex-row">
+      {steps.map((s, i) => (
+        <li key={s.title} className="flex items-center gap-2">
+          <span
+            className={`flex h-8 w-8 items-center justify-center rounded-full border-2 ${
+              i <= current ? "border-brand bg-brand text-white" : "border-gray-300"
+            }`}
+          >
+            {i + 1}
+          </span>
+          <div>
+            <p className="font-medium">{s.title}</p>
+            {s.description && (
+              <p className="text-sm text-gray-500">{s.description}</p>
+            )}
+          </div>
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/frontend/components/syllabus-list.tsx
+++ b/frontend/components/syllabus-list.tsx
@@ -1,0 +1,25 @@
+interface SyllabusSection {
+  title: string;
+  lessons: string[];
+}
+
+export function SyllabusList({ sections }: { sections: SyllabusSection[] }) {
+  return (
+    <div className="space-y-4">
+      {sections.map((section) => (
+        <details key={section.title} className="group rounded-lg border p-3">
+          <summary className="cursor-pointer font-medium group-open:mb-2">
+            {section.title}
+          </summary>
+          <ul className="ml-4 list-disc space-y-1">
+            {section.lessons.map((lesson) => (
+              <li key={lesson} className="text-sm text-gray-600">
+                {lesson}
+              </li>
+            ))}
+          </ul>
+        </details>
+      ))}
+    </div>
+  );
+}

--- a/frontend/components/ui/button.tsx
+++ b/frontend/components/ui/button.tsx
@@ -1,0 +1,43 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none ring-offset-background",
+  {
+    variants: {
+      variant: {
+        default: "bg-brand text-white hover:bg-brand/90",
+        outline: "border border-brand text-brand bg-transparent hover:bg-brand/10",
+        ghost: "hover:bg-brand/10",
+      },
+      size: {
+        default: "h-10 px-4 py-2",
+        sm: "h-9 px-3",
+        lg: "h-11 px-8",
+        icon: "h-10 w-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, ...props }, ref) => (
+    <button
+      ref={ref}
+      className={cn(buttonVariants({ variant, size, className }))}
+      {...props}
+    />
+  )
+);
+Button.displayName = "Button";
+
+export { Button, buttonVariants };

--- a/frontend/components/ui/card.tsx
+++ b/frontend/components/ui/card.tsx
@@ -1,0 +1,15 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn("rounded-2xl border bg-white p-6 shadow-sm", className)}
+      {...props}
+    />
+  )
+);
+Card.displayName = "Card";
+
+export { Card };

--- a/frontend/lib/routes.ts
+++ b/frontend/lib/routes.ts
@@ -1,0 +1,4 @@
+// Centralized legacy route constants for easy integration
+export const LEGACY_UPLOAD_PATH = "/upload";
+export const LEGACY_PLAYER_PATH = "/player";
+// Update these if the backend routes differ.

--- a/frontend/lib/utils.ts
+++ b/frontend/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+export default nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "cl-ai-mvp-ui",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "autoprefixer": "10.4.16",
+    "class-variance-authority": "0.7.0",
+    "clsx": "1.2.1",
+    "framer-motion": "10.16.5",
+    "lucide-react": "0.291.0",
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "tailwind-merge": "2.0.0",
+    "tailwindcss": "3.4.1"
+  },
+  "devDependencies": {
+    "@types/node": "20.11.25",
+    "@types/react": "18.2.36",
+    "eslint": "8.55.0",
+    "eslint-config-next": "14.2.3",
+    "postcss": "8.4.31",
+    "typescript": "5.3.3"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,23 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    "./app/**/*.{js,ts,jsx,tsx}",
+    "./components/**/*.{js,ts,jsx,tsx}",
+  ],
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: ["Inter", "sans-serif"],
+      },
+      colors: {
+        brand: {
+          DEFAULT: "#4f46e5",
+        },
+      },
+      borderRadius: {
+        xl: "1rem",
+      },
+    },
+  },
+  plugins: [],
+};

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,45 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": [
+      "node"
+    ],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": [
+        "./*"
+      ]
+    },
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
## Summary
- add Next.js app router frontend with Tailwind + shadcn components
- introduce course catalog with Python Basics and design-your-own wrapper
- wrap legacy player in responsive layout and document integration steps
- remove committed package-lock and ignore to avoid binary file
- remove local course png and use remote placeholder to avoid unsupported binary assets

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e08f33be08331996acc33839bb19d