### PR TITLE
Fix default class pre-generation on Cloud Run

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -145,11 +145,23 @@ def _prepare_default_class() -> None:
 
 
     output_path = os.path.join("outputs", f"{DEFAULT_ID}.mp4")
-    if os.environ.get("FAL_KEY") and not os.path.exists(output_path):
+    if os.path.exists(output_path):
+        return
+
+    if os.environ.get("FAL_KEY"):
         try:
             run_musetalk(dst_audio, dst_avatar, output_path)
+            return
         except Exception as exc:  # best-effort
             print(f"Failed to generate default class: {exc}")
+
+    # Fallback to pre-rendered demo video if API generation is unavailable
+    src_video = os.path.join(src_dir, "video.mp4")
+    try:
+        if os.path.exists(src_video):
+            shutil.copyfile(src_video, output_path)
+    except Exception as exc:
+        print(f"Failed to copy demo video: {exc}")
 
 
 # Prepare default assets in the background so startup is quick


### PR DESCRIPTION
## Summary
- ensure `_prepare_default_class` copies `inputs/video.mp4` when MuseTalk API cannot run

## Testing
- `python -m py_compile app/main.py`
- `python - <<'PY'
import os
os.environ['ENABLE_DEFAULT_ASSETS']='1'
import app.main as main
main._prepare_default_class()
print('done')
print('outputs dir contents:', os.listdir('outputs'))
PY`

------
https://chatgpt.com/codex/tasks/task_e_689e1d2b5b588331b6f85fc09ef9489b